### PR TITLE
Scaffold Node.js/Express backend (server skeleton + /health + scores API parity)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "brainflip",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Node/Express backend scaffold for Brainflip migration",
+  "scripts": {
+    "start": "node server/app.js",
+    "dev": "nodemon server/app.js",
+    "test": "node --version"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.7"
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import scoresRouter from './routes/scores.js';
+
+const app = express();
+const PORT = process.env.PORT || 8001;
+
+app.use(express.json());
+
+app.get('/health', (req, res) => res.json({ status: 'ok' }));
+
+app.use('/api/scores', scoresRouter);
+
+// Placeholder root to avoid conflicting with Flask; will serve static later
+app.get('/', (req, res) => {
+  res.type('text/plain').send('Brainflip Node/Express scaffold is running.');
+});
+
+app.listen(PORT, () => {
+  console.log(`Brainflip Node server listening on http://localhost:${PORT}`);
+});

--- a/server/routes/scores.js
+++ b/server/routes/scores.js
@@ -1,0 +1,35 @@
+import { Router } from 'express';
+import { loadScores, saveScore } from '../services/scoresService.js';
+
+const router = Router();
+
+router.get('/', (req, res) => {
+  try {
+    const scores = loadScores();
+    res.json(scores);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to load scores' });
+  }
+});
+
+router.post('/', (req, res) => {
+  const { score } = req.body || {};
+  if (score === undefined) {
+    return res.status(400).json({ error: 'Score is required' });
+  }
+  const n = Number(score);
+  if (!Number.isInteger(n)) {
+    return res.status(400).json({ error: 'Invalid score format' });
+  }
+  if (n < 0) {
+    return res.status(400).json({ error: 'Score must be non-negative' });
+  }
+  try {
+    const topScores = saveScore(n);
+    res.json({ success: true, top_scores: topScores });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save score' });
+  }
+});
+
+export default router;

--- a/server/services/scoresService.js
+++ b/server/services/scoresService.js
@@ -1,0 +1,47 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const STORAGE_DIR = path.join(__dirname, '..', 'storage');
+const SCORES_FILE = path.join(STORAGE_DIR, 'scores.txt');
+const MAX_TOP_SCORES = 5;
+
+function ensureStorage() {
+  if (!fs.existsSync(STORAGE_DIR)) {
+    fs.mkdirSync(STORAGE_DIR, { recursive: true });
+  }
+  if (!fs.existsSync(SCORES_FILE)) {
+    fs.writeFileSync(SCORES_FILE, '');
+  }
+}
+
+export function loadScores() {
+  ensureStorage();
+  try {
+    const data = fs.readFileSync(SCORES_FILE, 'utf8');
+    const scores = data
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => parseInt(s, 10))
+      .filter((n) => Number.isInteger(n));
+    return scores.sort((a, b) => b - a).slice(0, MAX_TOP_SCORES);
+  } catch {
+    return [];
+  }
+}
+
+export function saveScore(n) {
+  ensureStorage();
+  const scores = loadScores();
+  scores.push(n);
+  const top = scores.sort((a, b) => b - a).slice(0, MAX_TOP_SCORES);
+  const text = top.map((s) => String(s)).join('\n') + '\n';
+  fs.writeFileSync(SCORES_FILE, text, 'utf8');
+  return top;
+}
+
+export default { loadScores, saveScore };


### PR DESCRIPTION
This PR scaffolds the Node/Express backend to begin the Flask→Node migration.

What’s included:
- package.json with ESM, scripts: `start`, `dev`, `test`
- server/app.js with Express, JSON parsing, `/health`, and wiring for `/api/scores`
- server/routes/scores.js implementing parity validations and JSON shapes
- server/services/scoresService.js with file-based persistence in `server/storage/scores.txt`
- server/storage/.gitkeep to keep the directory tracked

Notes:
- The root route currently returns a placeholder text to avoid interfering with the existing Flask server. Static serving will be added in a follow-up PR.
- The scores storage is kept under `server/storage` to avoid clobbering Flask’s root-level `scores.txt` (which is in .gitignore). This keeps both backends runnable during transition.

How to run locally:
- `npm install`
- `npm run dev` (listens on PORT=8001 by default)
- Visit `http://localhost:8001/health`

Related issues:
- Refs #9 (Project structure)
- Refs #10 (Score service)
- Refs #11 (Express score routes)
- Refs #16 (Health endpoint)

After merge:
- Next PR will add Express static serving for `index.html` and images (Refs #12), followed by dev tooling (#13) and tests (#14).